### PR TITLE
[Feat] Drag and Drop 카드 컴포넌트 구현

### DIFF
--- a/app/profile/data/profile-data.tsx
+++ b/app/profile/data/profile-data.tsx
@@ -1,0 +1,14 @@
+import type { CardItem } from '@/components/dnd/card-list'
+
+export const profileCards: CardItem[] = [
+  { id: 'card-1', title: 'Capsule Render', content: '첫 번째 내용입니다.' },
+  { id: 'card-2', title: '간단 자기 소개', content: '두 번째 내용입니다.' },
+  { id: 'card-3', title: '이미지 업로드', content: '세 번째 내용입니다.' },
+  { id: 'card-4', title: '기술 스택', content: '세 번째 내용입니다.' },
+  { id: 'card-5', title: '프로젝트', content: '세 번째 내용입니다.' },
+  { id: 'card-6', title: '외부 활동 및 수상 내역', content: '세 번째 내용입니다.' },
+  { id: 'card-7', title: 'Stats', content: '세 번째 내용입니다.' },
+  { id: 'card-8', title: 'Most Used Languages', content: '세 번째 내용입니다.' },
+  { id: 'card-9', title: 'streak stats', content: '세 번째 내용입니다.' },
+  { id: 'card-10', title: 'Badge', content: '세 번째 내용입니다.' },
+]

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,9 +1,11 @@
 import Markdown from '@/components/markdown'
+import { profileCards } from './data/profile-data'
+import DndCardList from '@/components/dnd/card-list'
 
 export default function Profile() {
   return (
     <div className='flex w-full min-h-screen'>
-      <div className='flex-1'>write readme</div>
+      <DndCardList initialItems={profileCards} />
       <Markdown className='flex-2' />
     </div>
   )

--- a/app/project/data/project-data.tsx
+++ b/app/project/data/project-data.tsx
@@ -1,0 +1,15 @@
+import type { CardItem } from '@/components/dnd/card-list'
+
+export const projectCards: CardItem[] = [
+  { id: 'card-1', title: '프로젝트 메인 이미지 업로드', content: '첫 번째 내용입니다.' },
+  { id: 'card-2', title: '프로젝트 제목', content: '두 번째 내용입니다.' },
+  { id: 'card-3', title: '프로젝트 개요 및 간단 소개', content: '세 번째 내용입니다.' },
+  { id: 'card-4', title: '프로젝트 링크', content: '세 번째 내용입니다.' },
+  { id: 'card-5', title: '프로젝트 팀원', content: '세 번째 내용입니다.' },
+  { id: 'card-6', title: '프로젝트 기간', content: '세 번째 내용입니다.' },
+  { id: 'card-7', title: '기술 스택', content: '세 번째 내용입니다.' },
+  { id: 'card-8', title: '폴더 구조', content: '세 번째 내용입니다.' },
+  { id: 'card-9', title: '주요 기능', content: '세 번째 내용입니다.' },
+  { id: 'card-10', title: '담당 기능', content: '세 번째 내용입니다.' },
+  { id: 'card-11', title: 'Contact', content: '세 번째 내용입니다.' },
+]

--- a/app/project/page.tsx
+++ b/app/project/page.tsx
@@ -1,3 +1,10 @@
+import { projectCards } from './data/project-data'
+import DndCardList from '@/components/dnd/card-list'
+
 export default function Project() {
-  return <div>Project</div>
+  return (
+    <div>
+      <DndCardList initialItems={projectCards} />
+    </div>
+  )
 }

--- a/components/dnd/card-list.tsx
+++ b/components/dnd/card-list.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import { DndContext, closestCenter, type DragEndEvent } from '@dnd-kit/core'
+import { arrayMove, SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable'
+import { useState } from 'react'
+import DndCard from './dnd-card'
+import type { ReactNode } from 'react'
+
+export interface CardItem {
+  id: string
+  title: string
+  content: ReactNode
+}
+
+interface CardListProps {
+  initialItems: CardItem[]
+}
+
+const DndCardList = ({ initialItems }: CardListProps) => {
+  const [items, setItems] = useState(initialItems)
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event
+    if (!over) return
+
+    if (active.id !== over.id) {
+      const oldIndex = items.findIndex((item) => item.id === active.id)
+      const newIndex = items.findIndex((item) => item.id === over.id)
+
+      setItems(arrayMove(items, oldIndex, newIndex))
+    }
+  }
+
+  return (
+    <DndContext collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+      <SortableContext items={items.map((item) => item.id)} strategy={verticalListSortingStrategy}>
+        <div className='flex flex-col gap-4 p-10'>
+          {items.map((item) => (
+            <DndCard key={item.id} id={item.id} title={item.title}>
+              {item.content}
+            </DndCard>
+          ))}
+        </div>
+      </SortableContext>
+    </DndContext>
+  )
+}
+
+export default DndCardList

--- a/components/dnd/dnd-card.tsx
+++ b/components/dnd/dnd-card.tsx
@@ -1,0 +1,48 @@
+'use client'
+
+import { Card, CardTitle } from '@/components/ui/card'
+import { Menu, CircleMinus, CirclePlus } from 'lucide-react'
+import { useState, type ReactNode } from 'react'
+import { useSortable } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+
+interface DndCardProps {
+  id: string
+  title: string
+  children: ReactNode
+}
+
+const DndCard = ({ id, title, children }: DndCardProps) => {
+  const [collapsed, setCollapsed] = useState(false)
+
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id,
+  })
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  }
+
+  return (
+    <Card ref={setNodeRef} style={style} className='p-6'>
+      <section className='flex justify-between items-center'>
+        <div className='flex items-center gap-4'>
+          <Menu className='cursor-pointer' {...attributes} {...listeners} />
+          <CardTitle>{title}</CardTitle>
+        </div>
+
+        {collapsed ? (
+          <CirclePlus onClick={() => setCollapsed(false)} className='cursor-pointer' />
+        ) : (
+          <CircleMinus onClick={() => setCollapsed(true)} className='cursor-pointer' />
+        )}
+      </section>
+
+      {!collapsed && <section>{children}</section>}
+    </Card>
+  )
+}
+
+export default DndCard

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "write-me",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
         "@uiw/react-md-editor": "^4.0.7",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -51,6 +53,59 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
   },
   "dependencies": {
     "@uiw/react-md-editor": "^4.0.7",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.503.0",


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

- @dnd-kit/core, @dnd-kit/sortable 기반으로 드래그 앤 드롭 가능한 카드 컴포넌트 구현
- 각 카드 컴포넌트는 id, title, children을 받으며 아이콘으로 접기/펼치기 기능 포함
- 드래그 핸들(Menu icon)을 이용해 사용자가 카드 순서를 자유롭게 변경 가능
- 리스트 내 카드 구성은 외부에서 initialItems를 통해 유연하게 주입 가능하도록 설계

## 🧱 구성

**DndCard.tsx: 드래그 가능한 개별 카드 컴포넌트**
- 접기/펼치기 가능
- useSortable 사용

**CardList.tsx: 카드들을 드래그 가능한 리스트로 묶어주는 컴포넌트**

- DndContext, SortableContext 래핑
- onDragEnd에서 순서 재배치 (arrayMove)

**project-card-data.tsx, profile-card-data.tsx: 각 페이지별 카드 데이터 분리**
