### PR TITLE
[Feat] Toast 라이브러리 Sonner 적용 및 복사 완료/에러 알림 추가

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import localFont from 'next/font/local'
 import Header from '@/components/layout/header'
 import { Metadata } from 'next'
 import { ThemeProvider } from '@/components/theme-provider'
+import { Toaster } from 'sonner'
 
 const pretendard = localFont({
   src: '../public/fonts/PretendardVariable.woff2',
@@ -36,6 +37,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
         >
           <Header />
           <main className='flex-1 overflow-auto'>{children}</main>
+          <Toaster richColors position='top-center' />
         </ThemeProvider>
       </body>
     </html>

--- a/app/project/page.tsx
+++ b/app/project/page.tsx
@@ -28,7 +28,7 @@ export default function Project() {
   return (
     <div className='flex w-full min-h-screen py-4'>
       <div className='flex flex-col flex-1 gap-4 px-10'>
-        <InfoContents />
+        <InfoContents markdown={markdown} />
         <DndCardList items={cards} onToggleCollapse={onToggleCollapse} onReorder={setOrder} />
       </div>
       <Markdown className='flex-2' value={markdown} />

--- a/components/file-actions.tsx
+++ b/components/file-actions.tsx
@@ -1,5 +1,6 @@
 import { Card, IconButton } from '@/components/ui'
 import { Copy, Download } from 'lucide-react'
+import { toast } from 'sonner'
 
 interface FileActionsProps {
   markdown: string
@@ -9,9 +10,10 @@ const FileActions = ({ markdown }: FileActionsProps) => {
   const handleCopy = async () => {
     try {
       await navigator.clipboard.writeText(markdown)
-      alert('복사되었습니다.')
+      toast.success('복사가 완료되었습니다! ✨')
     } catch (err) {
-      alert(err)
+      console.error(err)
+      toast.error('앗, 복사에 실패했어요. 다시 시도해주세요 😢')
     }
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "next-themes": "^0.4.6",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "sonner": "^2.0.5",
         "tailwind-merge": "^3.3.0"
       },
       "devDependencies": {
@@ -8051,6 +8052,16 @@
       "optional": true,
       "dependencies": {
         "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.5.tgz",
+      "integrity": "sha512-YwbHQO6cSso3HBXlbCkgrgzDNIhws14r4MO87Ofy+cV2X7ES4pOoAK3+veSmVTvqNx1BWUxlhPmZzP00Crk2aQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map-js": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "next-themes": "^0.4.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "sonner": "^2.0.5",
     "tailwind-merge": "^3.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

closes #31

## 📋 작업 내용

- `README` 복사 기능에 대해 사용자에게 피드백을 제공하기 위해 toast 알림 도입
- `Sonner` 라이브러리를 사용하여 `복사 완료`, `복사 실패` 토스트 메시지 출력

## 라이브러리 선택 이유: `Sonner`

| 기준 | Sonner |
|------|--------------|
| 사용 편의성 | `toast.success()`, `toast.error()` 로 간단하게 사용 가능 |
| Tailwind + shadcn/ui와의 호환성 | 내부적으로 `@radix-ui/react-toast` 기반으로 되어 있어 shadcn 스타일과 충돌 없음 |
| 다크모드 자동 지원 | 시스템 다크모드에 따라 자동으로 토스트 스타일 반영 (`theme="system"`) |
| 빠른 UX | 가볍고 렌더링 속도가 빠름 |
| JSX 지원 | toast 내에 `<br />`, 커스텀 컴포넌트 등 JSX 형태로 다양한 메시지 출력 가능
