### PR TITLE
[Feat] README fork 페이지 UI 구현

### DIFF
--- a/app/gallery/[id]/fork/_components/index.ts
+++ b/app/gallery/[id]/fork/_components/index.ts
@@ -1,0 +1,1 @@
+export { default as Info } from './info'

--- a/app/gallery/[id]/fork/_components/info.tsx
+++ b/app/gallery/[id]/fork/_components/info.tsx
@@ -1,0 +1,15 @@
+interface InfoProps {
+  user: string
+  className?: string
+}
+
+const Info = ({ user, className }: InfoProps) => {
+  return (
+    <div className={`py-3 px-4 bg-sky-200 pr-40 ${className}`}>
+      <span className='font-bold'>{user}</span>님의 README를 Fork하여 새로운 README를 작성중입니다.
+      자유롭게 수정하여 나만의 README를 만들어보세요! ✨
+    </div>
+  )
+}
+
+export default Info

--- a/app/gallery/[id]/fork/page.tsx
+++ b/app/gallery/[id]/fork/page.tsx
@@ -1,0 +1,22 @@
+import Markdown from '@/components/markdown'
+import { Info } from './_components'
+import FileActions from '@/components/file-actions'
+
+const Page = () => {
+  const data = {
+    user: 'ssuminii',
+    markdown: '# title',
+  }
+
+  return (
+    <div className='flex flex-col gap-6 py-6 h-full'>
+      <div className='flex items-center justify-between mx-10'>
+        <Info user={data.user} />
+        <FileActions markdown={''} />
+      </div>
+      <Markdown value={data.markdown} className='flex-1' />
+    </div>
+  )
+}
+
+export default Page

--- a/app/gallery/[id]/page.tsx
+++ b/app/gallery/[id]/page.tsx
@@ -1,0 +1,5 @@
+const Page = () => {
+  return <div>Page</div>
+}
+
+export default Page

--- a/app/gallery/_components/contents.tsx
+++ b/app/gallery/_components/contents.tsx
@@ -3,11 +3,20 @@
 import { ReadmeCard } from './'
 import { AddButton } from '@/components/ui'
 import { mockReadmeCards } from '@/mocks/gallery'
+import { useRouter } from 'next/navigation'
 
 const Contents = () => {
+  const router = useRouter()
+
   return (
     <div className='relative flex flex-col items-center w-full'>
-      <AddButton onClick={() => {}} label='README 등록하기' className='absolute right-40' />
+      <AddButton
+        onClick={() => {
+          router.push('/gallery/new')
+        }}
+        label='README 등록하기'
+        className='absolute right-40'
+      />
 
       <div className='flex flex-wrap justify-center gap-6 mt-10'>
         {mockReadmeCards.map((mockReadmeCard) => (

--- a/app/gallery/_components/readme-card.tsx
+++ b/app/gallery/_components/readme-card.tsx
@@ -1,16 +1,25 @@
-import { Button, Card } from '@/components/ui'
+'use client'
+
+import { Button, Card, LikeButton } from '@/components/ui'
 import Image from 'next/image'
-import { LikeButton } from '@/components/ui'
+import { useRouter } from 'next/navigation'
 import type { ReadmeCardProps } from '@/types'
 
 const ReadmeCard = ({ title, author, thumbnailUrl, liked, likes }: ReadmeCardProps) => {
+  const router = useRouter()
+
   return (
     <Card className='flex flex-col p-4 gap-1 cursor-pointer'>
       <h1 className='text-lg font-semibold'>{title}</h1>
       <span className='text-sm text-gray-600'>{author}</span>
       <Image src={thumbnailUrl} alt={`${title} thumnail`} width={300} height={120} />
       <div className='flex justify-between items-center'>
-        <Button className='bg-point rounded-full w-fit text-black font-semibold hover:bg-point-hover px-6'>
+        <Button
+          className='bg-point rounded-full w-fit text-black font-semibold hover:bg-point-hover px-6'
+          onClick={() => {
+            router.push('/gallery/1/fork')
+          }}
+        >
           Fork
         </Button>
         <LikeButton count={likes} liked={liked} onClick={() => console.log('❤️')} />

--- a/app/gallery/new/page.tsx
+++ b/app/gallery/new/page.tsx
@@ -1,0 +1,5 @@
+const Page = () => {
+  return <div>리드미 등록 페이지</div>
+}
+
+export default Page

--- a/components/file-actions.tsx
+++ b/components/file-actions.tsx
@@ -1,4 +1,6 @@
-import { Card, IconButton } from '@/components/ui'
+'use client'
+
+import { IconButton } from '@/components/ui'
 import { Copy, Download } from 'lucide-react'
 import { toast } from 'sonner'
 
@@ -28,23 +30,20 @@ const FileActions = ({ markdown }: FileActionsProps) => {
   }
 
   return (
-    <Card className='flex flex-col gap-3 p-4 bg-muted/30'>
-      <h2 className='text-base font-semibold'>README 저장</h2>
-      <div className='grid grid-cols-1 sm:grid-cols-2 gap-4'>
-        <div className='flex items-center justify-center gap-3 rounded-lg border p-3 shadow-sm'>
-          <span className='text-sm text-center'>
-            마크다운 파일 <br /> 다운로드
-          </span>
-          <IconButton icon={Download} text='Download' onClick={handleDownload} />
-        </div>
-        <div className='flex items-center justify-center gap-3 rounded-lg border p-3 shadow-sm'>
-          <span className='text-sm text-center'>
-            마크다운 <br /> 복사
-          </span>
-          <IconButton icon={Copy} text='Copy' onClick={handleCopy} />
-        </div>
+    <div className='grid grid-cols-1 sm:grid-cols-2 gap-4'>
+      <div className='flex items-center justify-center gap-3 rounded-lg border p-3 shadow-sm'>
+        <span className='text-sm text-center'>
+          마크다운 파일 <br /> 다운로드
+        </span>
+        <IconButton icon={Download} text='Download' onClick={handleDownload} />
       </div>
-    </Card>
+      <div className='flex items-center justify-center gap-3 rounded-lg border p-3 shadow-sm'>
+        <span className='text-sm text-center'>
+          마크다운 <br /> 복사
+        </span>
+        <IconButton icon={Copy} text='Copy' onClick={handleCopy} />
+      </div>
+    </div>
   )
 }
 

--- a/components/info-contents.tsx
+++ b/components/info-contents.tsx
@@ -21,7 +21,10 @@ const InfoContents = ({ markdown }: InfoContentsProps) => {
           버튼으로 항목을 삭제하거나 추가할 수 있어요.
         </li>
       </ul>
-      <FileActions markdown={markdown} />
+      <Card className='flex flex-col gap-3 p-4 bg-muted/30'>
+        <h2 className='text-base font-semibold'>README 저장</h2>
+        <FileActions markdown={markdown} />
+      </Card>
     </Card>
   )
 }

--- a/components/markdown.tsx
+++ b/components/markdown.tsx
@@ -5,7 +5,7 @@ import { useTheme } from 'next-themes'
 import { useMounted } from '@/hooks'
 
 interface MarkdownProps {
-  className: string
+  className?: string
   value: string
 }
 


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

closes #37

## 📋 작업 내용

- README fork 페이지 UI 구현
  - FileActions 컴포넌트 수정
  - InfoContents 컴포넌트 수정

## 📸 스크린샷 (선택 사항)

<img width="1790" alt="image" src="https://github.com/user-attachments/assets/f7e9b566-f72e-4015-acaf-81a83b1e87a7" />
