### PR TITLE
[feat] README 상세페이지 Supabase 데이터 연동

### DIFF
--- a/app/gallery/[id]/page.tsx
+++ b/app/gallery/[id]/page.tsx
@@ -1,33 +1,33 @@
 import { Comments } from './_components'
 import { TagList } from '@/components/ui'
-import { LikeButton } from '@/components/like'
+import { LikeButtonContainer } from '@/components/like'
 import Link from 'next/link'
 import { mockReadme } from '@/mocks/gallery'
 import Preview from '@/components/preview'
+import { getReadmeById } from '@/lib/readme/get-readme-id'
 
-const Page = () => {
+const Page = async ({ params }: { params: Promise<{ id: string }> }) => {
+  const { id } = await params
+  const readme = await getReadmeById(id)
+
   return (
     <main className='flex p-10 gap-20'>
       <article className='flex flex-col gap-6 flex-3'>
         <header className='flex flex-col gap-2'>
-          <h1 className='text-2xl font-semibold'>{mockReadme.title}</h1>
-          <p className='text-sm text-gray-600'>@{mockReadme.author}</p>
+          <h1 className='text-2xl font-semibold'>{readme?.title}</h1>
+          <p className='text-sm text-gray-600'>@{readme?.author.split('@')[0]}</p>
           <div className='flex gap-2'>
             <Link
-              href={`/gallery/${mockReadme.id}/fork`}
+              href={`/gallery/${readme?.id}/fork`}
               className='border py-1 text-center w-[68px] bg-point hover:bg-point-hover rounded-sm text-sm'
             >
               Fork
             </Link>
-            <LikeButton
-              count={mockReadme.likes}
-              liked={mockReadme.liked}
-              className='border py-1 w-[68px] flex justify-center rounded-sm'
-            />
+            <LikeButtonContainer readmeId={id} />
           </div>
-          <TagList tags={mockReadme.hashtags} isDefault />
+          <TagList tags={readme?.hashtags} isDefault />
         </header>
-        <Preview source={mockReadme.source} />
+        <Preview source={readme?.source} />
       </article>
       <aside className='flex-1'>
         <Comments comments={mockReadme.comments} />

--- a/components/preview.tsx
+++ b/components/preview.tsx
@@ -4,7 +4,7 @@ import { useTheme } from 'next-themes'
 import MDEditor from '@uiw/react-md-editor'
 
 interface PreviewProps {
-  source: string
+  source: string | undefined
 }
 
 const Preview = ({ source }: PreviewProps) => {

--- a/components/ui/tag-list.tsx
+++ b/components/ui/tag-list.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react'
 import { Tag } from './'
 
 interface TagListProps {
-  tags: string[]
+  tags: string[] | undefined
   className?: string
   onRemove?: (label: string) => void
   selectable?: boolean
@@ -24,7 +24,7 @@ export const TagList = ({ tags, className, onRemove, selectable, isDefault }: Ta
 
   return (
     <div className='flex flex-wrap gap-2'>
-      {tags.map((tag) => (
+      {tags?.map((tag) => (
         <Tag
           key={tag}
           label={tag}

--- a/lib/readme/get-readme-id.ts
+++ b/lib/readme/get-readme-id.ts
@@ -1,0 +1,18 @@
+import { createClient } from '../supabase/supabase-server';
+import type { CreateReadme } from '@/types';
+
+export async function getReadmeById(id: string): Promise<CreateReadme | null> {
+  const supabase = await createClient();
+
+  const { data, error } = await supabase
+    .from('readmes')
+    .select('*')     
+    .eq('id', id)
+    .single();
+
+  if (error) {
+    throw new Error(`상세 페이지 데이터 불러오기 실패: ${error.message}`);
+  }
+
+  return data;
+}


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

closes #50

## 📋 작업 내용

- supabase readmes 테이블에서 특정 id로 readme 데이터를 조회하는 `getReadmeById` 함수 추가
- 기존에 mock 데이터를 사용하던 상세 페이지 실제 Supabase 데이터로 대체
  - title, author, hashtags, source, id 등을 실제 값으로 렌더링되도록 수정
- `params.id`를 기반으로 SSR 방식으로 readme 데이터 패칭
