### PR TITLE
[Feat] readme 목록 쿼리에 placeholderData 적용 (UX 최적화)

### DIFF
--- a/hooks/queries/useReadmesQuery.tsx
+++ b/hooks/queries/useReadmesQuery.tsx
@@ -6,6 +6,6 @@ export function useReadmesQuery(keyword: string) {
     queryKey: ['readmes', keyword],
     queryFn: () => getReadmes(keyword),
     staleTime: 1000 * 60 * 5,
-    gcTime: 1000 * 60 * 10,
+    placeholderData: (previousData) => previousData,
   })
 }


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

closes #56 

## 📋 작업 내용

- `useReadmesQuery` 훅에 `placeholderData: (previousData) => previousData` 옵션 추가
- 검색어(queryKey)가 변경될 때 이전 데이터를 유지하도록 설정하여 깜빡임 방지
