### PR TITLE
[Refactor] SSR에 데이터를 placeholderData로 넘겨 초기 렌더링 UX 개선

### DIFF
--- a/app/gallery/_components/contents.tsx
+++ b/app/gallery/_components/contents.tsx
@@ -3,15 +3,17 @@
 import { ReadmeCard } from './'
 import { AddButton } from '@/components/ui'
 import { useReadmesQuery } from '@/hooks/queries'
+import type { CreateReadme } from '@/types'
 import { useRouter } from 'next/navigation'
 
 interface ContentsProps {
   keyword: string
+  readmes: CreateReadme[]
 }
 
-const Contents = ({ keyword }: ContentsProps) => {
+const Contents = ({ keyword, readmes }: ContentsProps) => {
   const router = useRouter()
-  const { data } = useReadmesQuery(keyword)
+  const { data } = useReadmesQuery(keyword, readmes)
 
   return (
     <div className='relative flex flex-col items-center w-full'>

--- a/app/gallery/page.tsx
+++ b/app/gallery/page.tsx
@@ -1,10 +1,12 @@
 import { TagList } from '@/components/ui'
 import { Contents, SearchBar, Title } from './_components'
+import { getReadmes } from '@/lib/readme'
 
 const TAGS = ['Frontend', 'Backend', 'Stack', 'Profile', 'Project', 'Simple']
 
 export default async function Gallery({ searchParams }: { searchParams: Promise<{ q?: string }> }) {
   const { q: keyword = '' } = await searchParams
+  const readmes = await getReadmes(keyword)
 
   return (
     <div className='flex flex-col items-center gap-8 p-10'>
@@ -13,7 +15,7 @@ export default async function Gallery({ searchParams }: { searchParams: Promise<
         <SearchBar />
         <TagList tags={TAGS} selectable />
       </div>
-      <Contents keyword={keyword} />
+      <Contents keyword={keyword} readmes={readmes} />
     </div>
   )
 }

--- a/hooks/queries/readme.ts
+++ b/hooks/queries/readme.ts
@@ -1,13 +1,13 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { createReadme, getReadmeById, getReadmes } from '@/lib/readme'
-import type { CreateReadmeInput } from '@/types'
+import type { CreateReadme, CreateReadmeInput } from '@/types'
 
-export function useReadmesQuery(keyword: string) {
+export function useReadmesQuery(keyword: string, initialReadmes: CreateReadme[]) {
   return useQuery({
     queryKey: ['readmeList', keyword],
     queryFn: () => getReadmes(keyword),
     staleTime: 1000 * 60 * 5,
-    placeholderData: (previousData) => previousData,
+    placeholderData: initialReadmes,
   })
 }
 


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

closes #66

## 📋 작업 내용

- 서버 컴포넌트(Gallery)에서 README 데이터를 SSR로 미리 가져오도록 구현
- `useReadmesQuery` 훅에서 전달받은 데이터를 `placeholderData`로 설정
- SSR에서 받은 데이터를 클라이언트에서 즉시 렌더링 -> 로딩 스피너 없이 콘텐츠가 바로 보여져 사용자 경험 향상
